### PR TITLE
Update merge-deep and deep-extend transitive dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "yarn": "1.22.4"
   },
   "resolutions": {
-    "js-beautify": "1.10.3"
+    "js-beautify": "1.10.3",
+    "deep-extend": "0.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5724,15 +5724,10 @@ deep-equal@^1.0.1, deep-equal@^1.1.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-extend@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
-  integrity sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=
-
-deep-extend@^0.6.0:
+deep-extend@0.6.0, deep-extend@^0.4.0, deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"


### PR DESCRIPTION
Resolves https://github.com/advisories/GHSA-r6rj-9ch6-g264 and https://github.com/advisories/GHSA-hr2v-3952-633q

- Update merge-deep to v3.0.3
- Update deep-extend to 0.6.0