### PR TITLE
React 19 compatibility: object prop defaults, types entry, R19 test rig

### DIFF
--- a/packages/react-vis/jest.polyfills.js
+++ b/packages/react-vis/jest.polyfills.js
@@ -1,0 +1,13 @@
+/*eslint-env node*/
+// Temporary shims for the React 19 upgrade experiment: React 19 requires
+// modern platform globals that jest 25's sandboxed jsdom does not expose.
+if (typeof global.queueMicrotask === 'undefined') {
+  global.queueMicrotask = cb => Promise.resolve().then(cb);
+}
+if (typeof global.MessageChannel === 'undefined') {
+  global.MessageChannel = require('worker_threads').MessageChannel;
+}
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = require('util').TextEncoder;
+  global.TextDecoder = require('util').TextDecoder;
+}

--- a/packages/react-vis/jest.react19.config.js
+++ b/packages/react-vis/jest.react19.config.js
@@ -1,4 +1,6 @@
 /*eslint-env node*/
+// Temporary config for the React 19 upgrade experiment: runs only the
+// enzyme-free smoke test, since the enzyme adapter cannot load under React 19.
 const path = require('path');
 
 module.exports = {
@@ -6,6 +8,5 @@ module.exports = {
     '^.+\\.js$': path.resolve(__dirname, './jestBabelTransform.js')
   },
   setupFiles: ['./jest.polyfills.js'],
-  setupFilesAfterEnv: ['./jest.setup.js'],
-  snapshotSerializers: ['enzyme-to-json/serializer']
+  testMatch: ['**/tests/react19-smoke.test.js']
 };

--- a/packages/react-vis/package.json
+++ b/packages/react-vis/package.json
@@ -7,9 +7,11 @@
   "main": "dist",
   "module": "es",
   "jsnext:main": "es",
+  "types": "./react-vis.d.ts",
   "files": [
     "dist",
-    "es"
+    "es",
+    "react-vis.d.ts"
   ],
   "repository": {
     "type": "git",
@@ -76,18 +78,18 @@
     "jsdom": "^9.9.1",
     "node-sass": "^4.9.3",
     "prettier": "^1.14.2",
-    "react": "^16.0.0",
+    "react": "^19.0.0",
     "react-addons-test-utils": ">=15.4.2",
-    "react-dom": "^16.0.0",
-    "react-test-renderer": "^16.13.1",
+    "react-dom": "^19.0.0",
+    "react-test-renderer": "^19.0.0",
     "react-vis-showcase": "^0.1.0",
     "stylelint": "^7.7.1",
     "stylelint-config-standard": "^15.0.1",
     "uglify-js": "^2.8.22"
   },
   "peerDependencies": {
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "react": "^16.8.3 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^16.8.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "keywords": [
     "d3",

--- a/packages/react-vis/react-vis.d.ts
+++ b/packages/react-vis/react-vis.d.ts
@@ -1,0 +1,1675 @@
+/* oxlint-disable @typescript-eslint/no-empty-interface */
+declare module 'react-vis' {
+  import {
+    Component,
+    type CSSProperties,
+    type FC,
+    type FocusEventHandler,
+    type MouseEvent,
+    type MouseEventHandler,
+    PureComponent,
+    type ReactNode,
+    type TouchEventHandler,
+    type WheelEventHandler,
+  } from 'react';
+
+  export interface AbstractSeriesPoint {
+    [key: string]: any;
+  }
+
+  export type RVMouseEventHandler = MouseEventHandler<HTMLElement>;
+  export type RVTouchEventHandler = TouchEventHandler<HTMLElement>;
+  export type RVWheelEventHandler = WheelEventHandler<HTMLElement>;
+  export type RVFocusEventHandler = FocusEventHandler<HTMLElement>;
+
+  export type RVBrushEventHandler = (e?: {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+  }) => void;
+
+  export type RVSearchChangeEventHandler = (value: string) => void;
+
+  export type RVItemEventHandler = (
+    item: any,
+    index: number,
+    event: MouseEvent<HTMLElement>
+  ) => void;
+
+  export type RVValueEventHandler<T extends AbstractSeriesPoint> = (
+    datapoint: T,
+    event: MouseEvent<HTMLElement>
+  ) => void;
+
+  export type RVNearestXData<T extends AbstractSeriesPoint> = {
+    event: MouseEvent<HTMLElement>;
+    innerX: T['x'];
+    index: number;
+  };
+  export type RVNearestXEventHandler<T extends AbstractSeriesPoint> = (
+    datapoint: T,
+    data: RVNearestXData<T>
+  ) => void;
+
+  export type RVNearestXYData<T extends AbstractSeriesPoint> = {
+    event: MouseEvent<HTMLElement>;
+    innerX: T['x'];
+    innerY: T['y'];
+    index: number;
+  };
+  export type RVNearestXYEventHandler<T extends AbstractSeriesPoint> = (
+    datapoint: T,
+    data: RVNearestXYData<T>
+  ) => void;
+
+  export type RVGet<T extends AbstractSeriesPoint, K extends keyof T> = (
+    datapoint: T
+  ) => T[K];
+  export type RVGetNull<T extends AbstractSeriesPoint> = (datapoint: T) => any;
+  export type RVGetAlignStyle = (
+    align: {horizontal: string; vertical: string},
+    x: number,
+    y: number
+  ) => CSSProperties;
+
+  export type RVTickFormat = (tick: any) => string;
+
+  export type RVItemsFormat = (values: Array<any>) => {value: any; title: any};
+  export type RVTitleFormat = (
+    values: Array<any>
+  ) => {value: any; title: any} | undefined;
+
+  export type RVHintFormat = (value: {
+    [key: string]: any;
+  }) => Array<{value: any; title: any}>;
+
+  export type RVPadAngle = (...args: Array<any>) => number | undefined;
+
+  export type RVSearchFn = (
+    items: Array<any>,
+    searchText: string
+  ) => Array<any>;
+
+  export type RVSortFn<T extends AbstractSeriesPoint> = (
+    a: T,
+    b: T,
+    accessor: (val: T) => number
+  ) => number;
+
+  export interface LineSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+    color?: string;
+  }
+
+  export interface LineMarkSeriesPoint extends AbstractSeriesPoint {
+    x: string | number | Date;
+    y: string | number | Date;
+    color?: string;
+    opacity?: string | number;
+    stroke?: string | number;
+    fill?: string | number;
+    size?: string | number;
+  }
+
+  export interface MarkSeriesPoint extends AbstractSeriesPoint {
+    x: string | number | Date;
+    y: string | number | Date;
+    color?: string;
+    opacity?: string | number;
+    stroke?: string | number;
+    fill?: string | number;
+    size?: string | number;
+  }
+
+  export interface HorizontalBarSeriesPoint extends AbstractSeriesPoint {
+    x: string | number;
+    y: string | number;
+    color?: string;
+    opacity?: string | number;
+    stroke?: string | number;
+    fill?: string | number;
+  }
+
+  export interface VerticalBarSeriesPoint extends AbstractSeriesPoint {
+    x: string | number;
+    y: number;
+    color?: string;
+    opacity?: string | number;
+    stroke?: string | number;
+    fill?: string | number;
+  }
+
+  export interface ArcSeriesPoint extends AbstractSeriesPoint {
+    angle0: number;
+    angle: number;
+    radius0: number;
+    radius: number;
+    color?: string | number;
+    opacity?: string | number;
+    stroke?: string | number;
+    fill?: string | number;
+  }
+
+  export interface AreaSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+    y0?: number;
+  }
+
+  export interface ContourSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+  }
+
+  export interface HeatmapSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+    color?: string | number;
+  }
+
+  export interface LabelSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+    label: string;
+    xOffset?: number;
+    yOffset?: number;
+    rotation?: number;
+  }
+
+  export interface CustomSVGSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+  }
+
+  export interface PolygonSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+  }
+
+  export interface RectSeriesPoint extends AbstractSeriesPoint {
+    x: string | number | Date;
+    x0: string | number | Date;
+    y: string | number | Date;
+    y0: string | number | Date;
+    color?: string | number;
+    opacity?: string | number;
+    stroke?: string | number;
+    fill?: string | number;
+  }
+  export type HorizontalRectSeriesPoint = RectSeriesPoint;
+  export interface VerticalRectSeriesPoint extends RectSeriesPoint {}
+
+  export interface WhiskerSeriesPoint extends AbstractSeriesPoint {
+    x: string | number | Date;
+    y: string | number | Date;
+    color?: string | number;
+    opacity?: string | number;
+    stroke?: string | number;
+    size?: string | number;
+    xVariance?: string | number;
+    yVariance?: string | number;
+  }
+
+  export interface TreemapPoint extends AbstractSeriesPoint {
+    title: string;
+    size: number;
+    opacity?: number;
+    color?: string | number;
+    style: CSSProperties;
+    children: Array<TreemapPoint>;
+  }
+
+  export interface ParallelCoordinatesPoint extends AbstractSeriesPoint {
+    [key: string]: number;
+  }
+
+  export interface RadialChartPoint extends AbstractSeriesPoint {
+    angle: number;
+    radius?: number;
+    label?: string;
+    subLabel?: string;
+    color?: string;
+    style?: object;
+    className?: string;
+  }
+
+  export interface SankeyPoint extends AbstractSeriesPoint {
+    name: string;
+    color?: string;
+    opacity?: number;
+    key?: string;
+  }
+
+  export interface SunburstPoint extends AbstractSeriesPoint {
+    title: string;
+    size: number;
+    color?: number;
+    label?: string;
+    labelStyle?: CSSProperties;
+    dontRotateLabel?: boolean;
+    children?: Array<SunburstPoint>;
+  }
+
+  export interface VoronoiPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+  }
+
+  export interface HexbinSeriesPoint extends AbstractSeriesPoint {
+    x: number;
+    y: number;
+  }
+
+  export interface DecorativeAxisPoint extends AbstractSeriesPoint {}
+  export interface RadarChartPoint extends AbstractSeriesPoint {}
+  export interface HighlightPoint extends AbstractSeriesPoint {}
+
+  export function makeHeightFlexible(component: Component): Component;
+  export function makeVisFlexible(component: Component): Component;
+  export function makeWidthFlexible(component: Component): Component;
+
+  export const AxisUtils: {
+    DIRECTION: {
+      VERTICAL: 'vertical';
+      HORIZONTAL: 'horizontal';
+    };
+    ORIENTATION: {
+      TOP: 'top';
+      LEFT: 'left';
+      RIGHT: 'right';
+      BOTTOM: 'bottom';
+      VERTICAL: 'vertical';
+      HORIZONTAL: 'horizontal';
+    };
+    getTicksTotalFromSize: (size: number) => number;
+    getTickValues: (
+      scale: Function,
+      tickTotal: number,
+      tickValues?: Array<number | string>
+    ) => Array<number | string>;
+  };
+
+  export const ScaleUtils: {
+    extractScalePropsFromProps: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      attributes: Array<string>
+    ) => {[key: string]: any};
+    getAttributeScale: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      attr: string
+    ) => Function;
+    getAttributeFunctor: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      attr: string
+    ) => any;
+    getAttr0Functor: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      attr: string
+    ) => any;
+    getAttributeValue: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      attr: string
+    ) => any;
+    getDomainByAccessor: (
+      allData: Array<any>,
+      accessor: Function,
+      accessor0: Function,
+      type: string
+    ) => Array<any>;
+    getFontColorFromBackground: (background?: string | null) => string | null;
+    getMissingScaleProps: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      data: Array<any>,
+      attributes: Array<string>
+    ) => {[key: string]: any};
+    getOptionalScaleProps: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>
+    ) => {[key: string]: any};
+    getScaleObjectFromProps: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      attr: string
+    ) => any;
+    getScalePropTypesByAttribute: (attr: string) => {[key: string]: any};
+    getXYPlotValues: (
+      props: AbstractSeriesProps<AbstractSeriesPoint>,
+      children: ReactNode
+    ) => {[key: string]: any};
+    literalScale: (defaultValue: any) => Function;
+  };
+
+  export interface AbstractSeriesProps<T extends AbstractSeriesPoint> {
+    _xValue?: T['_x'];
+    xDomain?: Array<T['x']>;
+    getX?: RVGet<T, 'x'>;
+    getX0?: RVGet<T, 'x0'>;
+    getNull?: RVGetNull<LineSeriesPoint>;
+    xRange?: Array<T['x']>;
+    size?: number | string;
+    xType?:
+      | 'linear'
+      | 'ordinal'
+      | 'category'
+      | 'literal'
+      | 'log'
+      | 'time'
+      | 'time-utc';
+    xDistance?: number;
+    xBaseValue?: T['x'];
+    _yValue?: T['_y'];
+    yDomain?: Array<T['y']>;
+    getY?: RVGet<T, 'y'>;
+    getY0?: RVGet<T, 'y0'>;
+    yRange?: Array<T['y']>;
+    yType?:
+      | 'linear'
+      | 'ordinal'
+      | 'category'
+      | 'literal'
+      | 'log'
+      | 'time'
+      | 'time-utc';
+    yDistance?: number;
+    yBaseValue?: T['y'];
+    _sizeValue?: T['_size'];
+    sizeDomain?: Array<T['size']>;
+    getSize?: RVGet<T, 'size'>;
+    getSize0?: RVGet<T, 'size0'>;
+    sizeRange?: Array<T['size']>;
+    sizeType?:
+      | 'linear'
+      | 'ordinal'
+      | 'category'
+      | 'literal'
+      | 'log'
+      | 'time'
+      | 'time-utc';
+    sizeDistance?: number;
+    sizeBaseValue?: T['size'];
+    _opacityValue?: T['_opacity'];
+    opacityDomain?: Array<T['opacity']>;
+    getOpacity?: RVGet<T, 'opacity'>;
+    getOpacity0?: RVGet<T, 'opacity0'>;
+    opacityRange?: Array<T['opacity']>;
+    opacityType?:
+      | 'linear'
+      | 'ordinal'
+      | 'category'
+      | 'literal'
+      | 'log'
+      | 'time'
+      | 'time-utc';
+    opacityDistance?: number;
+    opacityBaseValue?: T['opacity'];
+    _colorValue?: T['_color'];
+    colorDomain?: Array<T['color']> | Array<number>;
+    getColor?: RVGet<T, 'color'>;
+    getColor0?: RVGet<T, 'color0'>;
+    colorRange?: Array<T['color']>;
+    colorType?:
+      | 'linear'
+      | 'ordinal'
+      | 'category'
+      | 'literal'
+      | 'log'
+      | 'time'
+      | 'time-utc';
+    colorDistance?: number;
+    colorBaseValue?: T['color'];
+    width?: number;
+    height?: number;
+    data?: Array<T | Array<any>>;
+    onValueMouseOver?: RVValueEventHandler<T>;
+    onValueMouseOut?: RVValueEventHandler<T>;
+    onValueClick?: RVValueEventHandler<T>;
+    onValueRightClick?: RVValueEventHandler<T>;
+    onSeriesMouseOver?: RVMouseEventHandler;
+    onSeriesMouseOut?: RVMouseEventHandler;
+    onSeriesClick?: RVMouseEventHandler;
+    onSeriesRightClick?: RVMouseEventHandler;
+    onNearestX?: RVNearestXEventHandler<T>;
+    onNearestXY?: RVNearestXEventHandler<T>;
+    style?: CSSProperties;
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    stack?: boolean;
+    color?: string | number;
+    stroke?: string | number;
+    fill?: string | number;
+    opacity?: number;
+    fillDomain?: number[];
+    fillRange?: string[];
+  }
+  export class AbstractSeries<T> extends PureComponent<T> {}
+
+  export interface LineSeriesProps
+    extends AbstractSeriesProps<LineSeriesPoint> {
+    strokeStyle?: 'dashed' | 'solid';
+    curve?: string | Function;
+    strokeDasharray?: string;
+    strokeWidth?: number;
+  }
+  export class LineSeries extends AbstractSeries<LineSeriesProps> {}
+
+  export interface LineSeriesCanvasProps
+    extends AbstractSeriesProps<LineSeriesPoint> {
+    strokeStyle?: 'dashed' | 'solid';
+    curve?: string | Function;
+    getNull?: RVGetNull<LineSeriesPoint>;
+    strokeDasharray?: number[];
+    strokeWidth?: number;
+    size: number;
+  }
+  export class LineSeriesCanvas extends AbstractSeries<LineSeriesCanvasProps> {}
+
+  export interface HorizontalBarSeriesProps
+    extends AbstractSeriesProps<HorizontalBarSeriesPoint> {}
+  export class HorizontalBarSeries extends AbstractSeries<HorizontalBarSeriesProps> {}
+
+  export interface HorizontalBarSeriesCanvasProps
+    extends AbstractSeriesProps<HorizontalBarSeriesPoint> {}
+  export class HorizontalBarSeriesCanvas extends AbstractSeries<HorizontalBarSeriesCanvasProps> {}
+
+  export interface VerticalBarSeriesProps
+    extends AbstractSeriesProps<VerticalBarSeriesPoint> {}
+  export class VerticalBarSeries extends AbstractSeries<VerticalBarSeriesProps> {}
+
+  export interface VerticalBarSeriesCanvasProps
+    extends AbstractSeriesProps<VerticalBarSeriesPoint> {}
+  export class VerticalBarSeriesCanvas extends AbstractSeries<VerticalBarSeriesCanvasProps> {}
+
+  export interface VerticalRectSeriesProps
+    extends AbstractSeriesProps<VerticalRectSeriesPoint> {}
+  export class VerticalRectSeries extends AbstractSeries<VerticalRectSeriesProps> {}
+
+  export interface VerticalRectSeriesCanvasProps
+    extends AbstractSeriesProps<VerticalRectSeriesPoint> {}
+  export class VerticalRectSeriesCanvas extends AbstractSeries<VerticalRectSeriesCanvasProps> {}
+
+  export interface HorizontalRectSeriesProps
+    extends AbstractSeriesProps<HorizontalRectSeriesPoint> {}
+  export class HorizontalRectSeries extends AbstractSeries<HorizontalRectSeriesProps> {}
+
+  export interface HorizontalRectSeriesCanvasProps
+    extends AbstractSeriesProps<HorizontalRectSeriesPoint> {}
+  export class HorizontalRectSeriesCanvas extends AbstractSeries<HorizontalRectSeriesCanvasProps> {}
+
+  export interface LabelSeriesProps
+    extends AbstractSeriesProps<LabelSeriesPoint> {
+    allowOffsetToBeReversed?: boolean;
+    marginLeft?: number;
+    marginTop?: number;
+    rotation?: number;
+    labelAnchorX?: string;
+    labelAnchorY?: string;
+  }
+  export class LabelSeries extends AbstractSeries<LabelSeriesProps> {}
+
+  export interface PolygonSeriesProps
+    extends AbstractSeriesProps<PolygonSeriesPoint> {}
+  export class PolygonSeries extends AbstractSeries<PolygonSeriesProps> {}
+
+  export interface RectSeriesProps
+    extends AbstractSeriesProps<RectSeriesPoint> {
+    linePosAttr?: string;
+    valuePosAttr?: string;
+    lineSizeAttr?: string;
+    valueSizeAttr?: string;
+  }
+  export class RectSeries extends AbstractSeries<RectSeriesProps> {}
+
+  export interface RectSeriesCanvasProps
+    extends AbstractSeriesProps<RectSeriesPoint> {}
+  export class RectSeriesCanvas extends AbstractSeries<RectSeriesCanvasProps> {}
+
+  export interface MarkSeriesProps
+    extends AbstractSeriesProps<MarkSeriesPoint> {
+    getNull?: RVGetNull<MarkSeriesPoint>;
+    strokeWidth?: number;
+    size?: string | number;
+  }
+  export class MarkSeries extends AbstractSeries<MarkSeriesProps> {}
+
+  export interface MarkSeriesCanvasProps
+    extends AbstractSeriesProps<MarkSeriesPoint> {}
+  export class MarkSeriesCanvas extends AbstractSeries<MarkSeriesCanvasProps> {}
+
+  export interface WhiskerSeriesProps
+    extends AbstractSeriesProps<WhiskerSeriesPoint> {
+    strokeWidth?: number;
+  }
+  export class WhiskerSeries extends AbstractSeries<WhiskerSeriesProps> {}
+
+  export interface HeatmapSeriesProps
+    extends AbstractSeriesProps<HeatmapSeriesPoint> {}
+  export class HeatmapSeries extends AbstractSeries<HeatmapSeriesProps> {}
+
+  export interface HexbinSeriesProps
+    extends AbstractSeriesProps<HexbinSeriesPoint> {
+    radius?: number;
+  }
+  export class HexbinSeries extends AbstractSeries<HexbinSeriesProps> {}
+
+  export interface ContourSeriesProps
+    extends AbstractSeriesProps<ContourSeriesPoint> {
+    bandwidth?: number;
+    marginLeft?: number;
+    marginTop?: number;
+  }
+  export class ContourSeries extends AbstractSeries<ContourSeriesProps> {}
+
+  export interface CustomSVGSeriesProps
+    extends AbstractSeriesProps<CustomSVGSeriesPoint> {
+    customComponent?: string | Function;
+    marginLeft?: number;
+    marginTop?: number;
+  }
+  export class CustomSVGSeries extends AbstractSeries<CustomSVGSeriesProps> {}
+
+  type AreaSeriesProps = AbstractSeriesProps<AreaSeriesPoint>;
+
+  export class AreaSeries extends AbstractSeries<AreaSeriesProps> {}
+
+  export interface ArcSeriesProps extends AbstractSeriesProps<ArcSeriesPoint> {
+    _radiusValue?: ArcSeriesPoint['_radius'];
+    radiusDomain?: Array<ArcSeriesPoint['radius']>;
+    getRadius?: RVGet<ArcSeriesPoint, 'radius'>;
+    getRadius0?: RVGet<ArcSeriesPoint, 'radius0'>;
+    radiusRange?: Array<ArcSeriesPoint['radius']>;
+    radiusType?:
+      | 'linear'
+      | 'ordinal'
+      | 'category'
+      | 'literal'
+      | 'log'
+      | 'time'
+      | 'time-utc';
+    radiusDistance?: number;
+    radiusBaseValue?: ArcSeriesPoint['radius'];
+    _angleValue?: ArcSeriesPoint['_angle'];
+    angleDomain?: Array<ArcSeriesPoint['angle']>;
+    getAngle?: RVGet<ArcSeriesPoint, 'angle'>;
+    getAngle0?: RVGet<ArcSeriesPoint, 'angle0'>;
+    angleRange?: Array<ArcSeriesPoint['angle']>;
+    angleType?:
+      | 'linear'
+      | 'ordinal'
+      | 'category'
+      | 'literal'
+      | 'log'
+      | 'time'
+      | 'time-utc';
+    angleDistance?: number;
+    angleBaseValue?: ArcSeriesPoint['angle'];
+    center?: {
+      x?: number;
+      y?: number;
+    };
+    arcClassName?: string;
+    padAngle?: RVPadAngle | number;
+  }
+  export class ArcSeries extends AbstractSeries<ArcSeriesProps> {}
+
+  export interface LineMarkSeriesProps
+    extends AbstractSeriesProps<LineMarkSeriesPoint> {
+    strokeStyle?: 'dashed' | 'solid';
+    curve?: string | Function;
+    getNull?: RVGetNull<LineMarkSeriesPoint>;
+    lineStyle?: CSSProperties;
+    markStyle?: CSSProperties;
+  }
+  export class LineMarkSeries extends AbstractSeries<LineMarkSeriesProps> {}
+
+  export interface LineMarkSeriesCanvasProps
+    extends AbstractSeriesProps<LineMarkSeriesPoint> {}
+  export class LineMarkSeriesCanvas extends AbstractSeries<LineMarkSeriesCanvasProps> {}
+
+  export interface HintProps {
+    marginTop?: number;
+    marginLeft?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+    scales?: {[key: string]: any};
+    value?: {[key: string]: any};
+    format?: RVHintFormat;
+    style?: CSSProperties;
+    align?: {
+      horizontal?: 'auto' | 'left' | 'right' | 'leftEdge' | 'rightEdge';
+      vertical?: 'auto' | 'bottom' | 'top' | 'bottomEdge' | 'topEdge';
+    };
+    getAlignStyle?: RVGetAlignStyle;
+    orientation?: 'bottomleft' | 'bottomright' | 'topleft' | 'topright';
+  }
+  export class Hint<T = any> extends PureComponent<HintProps & T> {}
+
+  export interface BordersProps {
+    style?: {
+      bottom?: CSSProperties;
+      left?: CSSProperties;
+      right?: CSSProperties;
+      top?: CSSProperties;
+    };
+    marginTop?: number;
+    marginBottom?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+  }
+  export class Borders<T = any> extends PureComponent<BordersProps & T> {}
+
+  export interface CrosshairProps {
+    className?: string;
+    values?: Array<number | string | {[key: string]: any}>;
+    series?: {[key: string]: any};
+    innerWidth?: number;
+    innerHeight?: number;
+    marginLeft?: number;
+    marginTop?: number;
+    orientation?: 'left' | 'right';
+    itemsFormat?: RVItemsFormat;
+    titleFormat?: RVTitleFormat;
+    style?: {
+      line?: CSSProperties;
+      title?: CSSProperties;
+      box?: CSSProperties;
+    };
+  }
+  export class Crosshair<T = any> extends PureComponent<CrosshairProps & T> {}
+
+  export interface XYPlotProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    className?: string;
+    dontCheckIfEmpty?: boolean;
+    height: number;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    onClick?: RVMouseEventHandler;
+    onDoubleClick?: RVMouseEventHandler;
+    onMouseDown?: RVMouseEventHandler;
+    onMouseUp?: RVMouseEventHandler;
+    onMouseEnter?: RVMouseEventHandler;
+    onMouseLeave?: RVMouseEventHandler;
+    onMouseMove?: RVMouseEventHandler;
+    onTouchStart?: RVTouchEventHandler;
+    onTouchMove?: RVTouchEventHandler;
+    onTouchEnd?: RVTouchEventHandler;
+    onTouchCancel?: RVTouchEventHandler;
+    onWheel?: RVWheelEventHandler;
+    stackBy?:
+      | 'x'
+      | 'y'
+      | 'radius'
+      | 'angle'
+      | 'color'
+      | 'fill'
+      | 'stroke'
+      | 'opacity'
+      | 'size';
+    style?: CSSProperties;
+    width: number;
+  }
+  export class XYPlot<T = any> extends Component<XYPlotProps & T> {}
+
+  export interface DecorativeAxisProps
+    extends AbstractSeriesProps<DecorativeAxisPoint> {
+    axisDomain: Array<number>;
+    axisEnd: {
+      x?: number | string;
+      y?: number | string;
+    };
+    axisStart: {
+      x?: number | string;
+      y?: number | string;
+    };
+    numberOfTicks?: number;
+    tickValue?: RVTickFormat;
+    tickSize?: number;
+  }
+  export class DecorativeAxis extends AbstractSeries<DecorativeAxisProps> {}
+
+  export interface XAxisProps {
+    orientation?: 'top' | 'bottom';
+    attr?: string;
+    attrAxis?: string;
+    width?: number;
+    height?: number;
+    top?: number;
+    left?: number;
+    title?: string;
+    style?: {[key: string]: string | CSSProperties};
+    className?: string;
+    hideTicks?: boolean;
+    hideLine?: boolean;
+    on0?: boolean;
+    tickLabelAngle?: number;
+    tickSize?: number;
+    tickSizeInner?: number;
+    tickSizeOuter?: number;
+    tickPadding?: number;
+    tickValues?: Array<number | string>;
+    tickFormat?: RVTickFormat;
+    tickTotal?: number;
+    marginTop?: number;
+    marginBottom?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+  }
+  export const XAxis: FC<XAxisProps>;
+
+  export interface YAxisProps {
+    orientation?: 'left' | 'right';
+    attr?: string;
+    attrAxis?: string;
+    width?: number;
+    height?: number;
+    top?: number;
+    left?: number;
+    title?: string;
+    style?: {[key: string]: string | CSSProperties};
+    className?: string;
+    hideTicks?: boolean;
+    hideLine?: boolean;
+    on0?: boolean;
+    tickLabelAngle?: number;
+    tickSize?: number;
+    tickSizeInner?: number;
+    tickSizeOuter?: number;
+    tickPadding?: number;
+    tickValues?: Array<number | string>;
+    tickFormat?: RVTickFormat;
+    tickTotal?: number;
+    marginTop?: number;
+    marginBottom?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+  }
+  export const YAxis: FC<YAxisProps>;
+
+  export interface CircularGridLinesProps {
+    centerX?: number;
+    centerY?: number;
+    width?: number;
+    height?: number;
+    top?: number;
+    left?: number;
+    rRange?: Array<number>;
+    style?: CSSProperties;
+    tickValues?: Array<number>;
+    tickTotal?: number;
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    marginTop?: number;
+    marginBottom?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+  }
+  export class CircularGridLines<T = any> extends PureComponent<
+    CircularGridLinesProps & T
+  > {}
+
+  export interface GridLinesProps {
+    direction?: 'vertical' | 'horizontal';
+    attr: string;
+    width?: number;
+    height?: number;
+    top?: number;
+    left?: number;
+    style?: CSSProperties;
+    tickValues?: Array<number | string>;
+    tickTotal?: number;
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    marginTop?: number;
+    marginBottom?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+  }
+  export class GridLines<T = any> extends PureComponent<GridLinesProps & T> {}
+
+  export interface GradientDefsProps {
+    className?: string;
+  }
+  export class GradientDefs<T = any> extends PureComponent<
+    GradientDefsProps & T
+  > {}
+
+  export interface VerticalGridLinesProps {
+    direction?: 'vertical';
+    attr?: string;
+    width?: number;
+    height?: number;
+    top?: number;
+    left?: number;
+    style?: CSSProperties;
+    tickValues?: Array<number | string>;
+    tickTotal?: number;
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    marginTop?: number;
+    marginBottom?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+  }
+  export const VerticalGridLines: FC<VerticalGridLinesProps>;
+
+  export interface HorizontalGridLinesProps {
+    direction?: 'horizontal';
+    attr?: string;
+    width?: number;
+    height?: number;
+    top?: number;
+    left?: number;
+    style?: CSSProperties;
+    tickValues?: Array<number | string>;
+    tickTotal?: number;
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    marginTop?: number;
+    marginBottom?: number;
+    marginLeft?: number;
+    marginRight?: number;
+    innerWidth?: number;
+    innerHeight?: number;
+  }
+  export const HorizontalGridLines: FC<HorizontalGridLinesProps>;
+
+  export interface VoronoiProps {
+    className?: string;
+    extent?: Array<Array<number>>;
+    nodes: Array<VoronoiPoint>;
+    onBlur?: RVFocusEventHandler;
+    onClick?: RVMouseEventHandler;
+    onHover?: RVMouseEventHandler;
+    onMouseDown?: RVMouseEventHandler;
+    onMouseUp?: RVMouseEventHandler;
+    x?: Function;
+    y?: Function;
+  }
+  export const Voronoi: FC<VoronoiProps>;
+
+  export interface HighlightProps extends AbstractSeriesProps<HighlightPoint> {
+    enableX?: boolean;
+    enableY?: boolean;
+    highlightHeight?: number;
+    highlightWidth?: number;
+    highlightX?: string | number;
+    highlightY?: string | number;
+    isDrawing?: boolean;
+    setIsDrawing?: (isDrawing: boolean) => void;
+    onBrushStart?: RVMouseEventHandler;
+    onDragStart?: RVMouseEventHandler;
+    onBrush?: RVBrushEventHandler;
+    onDrag?: RVBrushEventHandler;
+    onBrushEnd?: RVBrushEventHandler;
+    onDragEnd?: RVBrushEventHandler;
+  }
+  export class Highlight extends AbstractSeries<HighlightProps> {}
+
+  export interface DiscreteColorLegendProps {
+    className?: string;
+    items: Array<
+      | {
+      title: string;
+      color?: string;
+      disabled?: boolean;
+    }
+      | string
+      | ReactNode
+    >;
+    onItemClick?: RVMouseEventHandler;
+    onItemMouseEnter?: RVItemEventHandler;
+    onItemMouseLeave?: RVItemEventHandler;
+    height?: number;
+    width?: number;
+    orientation?: 'vertical' | 'horizontal';
+  }
+  export const DiscreteColorLegend: FC<DiscreteColorLegendProps>;
+
+  export interface SearchableDiscreteColorLegendProps {
+    className?: string;
+    items: Array<
+      | {
+      title: string;
+      color?: string;
+      disabled?: boolean;
+    }
+      | string
+      | ReactNode
+    >;
+    onItemClick?: RVMouseEventHandler;
+    onItemMouseEnter?: RVItemEventHandler;
+    onItemMouseLeave?: RVItemEventHandler;
+    height?: number;
+    width?: number;
+    orientation?: 'vertical' | 'horizontal';
+    searchText?: string;
+    onSearchChange?: RVSearchChangeEventHandler;
+    searchPlaceholder?: string;
+    searchFn?: RVSearchFn;
+  }
+  export const SearchableDiscreteColorLegend: FC<SearchableDiscreteColorLegendProps>;
+
+  export interface ContinuousColorLegendProps {
+    className?: string;
+    height?: number;
+    endColor?: string;
+    endTitle: number | string;
+    midColor?: string;
+    midTitle?: number | string;
+    startColor?: string;
+    startTitle: number | string;
+    width?: number;
+  }
+  export const ContinuousColorLegend: FC<ContinuousColorLegendProps>;
+
+  export interface ContinuousSizeLegendProps {
+    className?: string;
+    circlesTotal?: number;
+    endSize?: number;
+    endTitle: number | string;
+    height?: number;
+    startSize?: number;
+    startTitle: number | string;
+    width?: number;
+  }
+  export const ContinuousSizeLegend: FC<ContinuousSizeLegendProps>;
+
+  export interface TreemapProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    className?: string;
+    data?: TreemapPoint;
+    height: number;
+    hideRootNode?: boolean;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    mode?:
+      | 'squarify'
+      | 'resquarify'
+      | 'slice'
+      | 'dice'
+      | 'slicedice'
+      | 'binary'
+      | 'circlePack'
+      | 'partition'
+      | 'partition-pivot';
+    onLeafClick?: RVValueEventHandler<TreemapPoint>;
+    onLeafMouseOver?: RVValueEventHandler<TreemapPoint>;
+    onLeafMouseOut?: RVValueEventHandler<TreemapPoint>;
+    useCirclePacking?: boolean;
+    padding?: number;
+    sortFunction?: RVSortFn<TreemapPoint>;
+    width: number;
+    getSize?: RVGet<TreemapPoint, 'size'>;
+    getColor?: RVGet<TreemapPoint, 'color'>;
+  }
+  export class Treemap<T = any> extends Component<TreemapProps & T> {}
+
+  export interface RadialChartProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    className?: string;
+    colorType?: string;
+    data: Array<{
+      angle?: number;
+      className?: string;
+      label?: string;
+      radius?: number;
+      style?: CSSProperties;
+    }>;
+    getAngle?: RVGet<RadialChartPoint, 'angle'>;
+    getAngle0?: RVGet<RadialChartPoint, 'angle0'>;
+    padAngle?: RVPadAngle | number;
+    getRadius?: RVGet<RadialChartPoint, 'radius'>;
+    getRadius0?: RVGet<RadialChartPoint, 'radius0'>;
+    getLabel?: RVGet<RadialChartPoint, 'label'>;
+    height: number;
+    labelsAboveChildren?: boolean;
+    labelsStyle?: CSSProperties;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    onValueClick?: RVValueEventHandler<RadialChartPoint>;
+    onValueMouseOver?: RVValueEventHandler<RadialChartPoint>;
+    onValueMouseOut?: RVValueEventHandler<RadialChartPoint>;
+    showLabels?: boolean;
+    style?: CSSProperties;
+    subLabel?: Function;
+    width: number;
+  }
+  export class RadialChart<T = any> extends Component<RadialChartProps & T> {}
+
+  export interface RadarChartProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    className?: string;
+    colorType?: string;
+    colorRange?: Array<string>;
+    data: Array<RadarChartPoint>;
+    domains: Array<{
+      name: string;
+      domain: Array<number>;
+      tickFormat?: RVTickFormat;
+    }>;
+    height: number;
+    hideInnerMostValues?: boolean;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    startingAngle?: number;
+    style?: {
+      axes?: CSSProperties;
+      labels?: CSSProperties;
+      polygons?: CSSProperties;
+    };
+    tickFormat?: RVTickFormat;
+    width: number;
+  }
+  export class RadarChart<T = any> extends Component<RadarChartProps & T> {}
+
+  export interface ParallelCoordinatesProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    brushing?: boolean;
+    className?: string;
+    colorType?: string;
+    colorRange?: Array<string>;
+    data: Array<ParallelCoordinatesPoint>;
+    domains: Array<{
+      name: string;
+      domain: Array<number>;
+      tickFormat?: RVTickFormat;
+    }>;
+    height: number;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    style?: {
+      axes?: CSSProperties;
+      labels?: CSSProperties;
+      lines?: CSSProperties;
+    };
+    showMarks?: boolean;
+    tickFormat?: RVTickFormat;
+    width: number;
+  }
+  export class ParallelCoordinates<T = any> extends Component<
+    ParallelCoordinatesProps & T
+  > {}
+
+  export interface SankeyProps {
+    align?: 'justify' | 'left' | 'right' | 'center';
+    className?: string;
+    hasVoronoi?: boolean;
+    height: number;
+    hideLabels?: boolean;
+    labelRotation?: number;
+    layout?: number;
+    links: Array<{
+      source: number | {[key: string]: any};
+      target: number | {[key: string]: any};
+    }>;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    nodePadding?: number;
+    nodes: Array<SankeyPoint>;
+    nodeWidth?: number;
+    onValueMouseOver?: RVValueEventHandler<SankeyPoint>;
+    onValueClick?: RVValueEventHandler<SankeyPoint>;
+    onValueMouseOut?: RVValueEventHandler<SankeyPoint>;
+    onLinkClick?: RVValueEventHandler<SankeyPoint>;
+    onLinkMouseOver?: RVValueEventHandler<SankeyPoint>;
+    onLinkMouseOut?: RVValueEventHandler<SankeyPoint>;
+    style?: {
+      links?: CSSProperties;
+      rects?: CSSProperties;
+      labels?: CSSProperties;
+    };
+    width: number;
+  }
+  export class Sankey<T = any> extends Component<SankeyProps & T> {}
+
+  export interface SunburstProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    getAngle?: RVGet<SunburstPoint, 'angle'>;
+    getAngle0?: RVGet<SunburstPoint, 'angle0'>;
+    className?: string;
+    colorType?: string;
+    data: SunburstPoint;
+    height: number;
+    hideRootNode?: boolean;
+    getLabel?: RVGet<SunburstPoint, 'label'>;
+    onValueClick?: RVValueEventHandler<SunburstPoint>;
+    onValueMouseOver?: RVValueEventHandler<SunburstPoint>;
+    onValueMouseOut?: RVValueEventHandler<SunburstPoint>;
+    getSize?: RVGet<SunburstPoint, 'size'>;
+    width: number;
+    padAngle?: RVPadAngle | number;
+  }
+  export class Sunburst<T = any> extends Component<SunburstProps & T> {}
+
+  export interface FlexibleXYPlotProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    className?: string;
+    dontCheckIfEmpty?: boolean;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    onClick?: RVMouseEventHandler;
+    onDoubleClick?: RVMouseEventHandler;
+    onMouseDown?: RVMouseEventHandler;
+    onMouseUp?: RVMouseEventHandler;
+    onMouseEnter?: RVMouseEventHandler;
+    onMouseLeave?: RVMouseEventHandler;
+    onMouseMove?: RVMouseEventHandler;
+    onTouchStart?: RVTouchEventHandler;
+    onTouchMove?: RVTouchEventHandler;
+    onTouchEnd?: RVTouchEventHandler;
+    onTouchCancel?: RVTouchEventHandler;
+    onWheel?: RVWheelEventHandler;
+    stackBy?:
+      | 'x'
+      | 'y'
+      | 'radius'
+      | 'angle'
+      | 'color'
+      | 'fill'
+      | 'stroke'
+      | 'opacity'
+      | 'size';
+    style?: CSSProperties;
+  }
+  export class FlexibleXYPlot<T = any> extends Component<
+    FlexibleXYPlotProps & T
+  > {}
+
+  export interface FlexibleWidthXYPlotProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    className?: string;
+    dontCheckIfEmpty?: boolean;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    onClick?: RVMouseEventHandler;
+    onDoubleClick?: RVMouseEventHandler;
+    onMouseDown?: RVMouseEventHandler;
+    onMouseUp?: RVMouseEventHandler;
+    onMouseEnter?: RVMouseEventHandler;
+    onMouseLeave?: RVMouseEventHandler;
+    onMouseMove?: RVMouseEventHandler;
+    onTouchStart?: RVTouchEventHandler;
+    onTouchMove?: RVTouchEventHandler;
+    onTouchEnd?: RVTouchEventHandler;
+    onTouchCancel?: RVTouchEventHandler;
+    onWheel?: RVWheelEventHandler;
+    stackBy?:
+      | 'x'
+      | 'y'
+      | 'radius'
+      | 'angle'
+      | 'color'
+      | 'fill'
+      | 'stroke'
+      | 'opacity'
+      | 'size';
+    style?: CSSProperties;
+  }
+  export class FlexibleWidthXYPlot<T = any> extends Component<
+    FlexibleWidthXYPlotProps & T
+  > {}
+
+  export interface FlexibleHeightXYPlotProps {
+    animation?:
+      | string
+      | {
+      stiffness?: number;
+      nonAnimatedProps?: Array<string>;
+      damping?: number;
+    }
+      | boolean;
+    className?: string;
+    dontCheckIfEmpty?: boolean;
+    margin?:
+      | {
+      left?: number;
+      top?: number;
+      right?: number;
+      bottom?: number;
+    }
+      | number;
+    onClick?: RVMouseEventHandler;
+    onDoubleClick?: RVMouseEventHandler;
+    onMouseDown?: RVMouseEventHandler;
+    onMouseUp?: RVMouseEventHandler;
+    onMouseEnter?: RVMouseEventHandler;
+    onMouseLeave?: RVMouseEventHandler;
+    onMouseMove?: RVMouseEventHandler;
+    onTouchStart?: RVTouchEventHandler;
+    onTouchMove?: RVTouchEventHandler;
+    onTouchEnd?: RVTouchEventHandler;
+    onTouchCancel?: RVTouchEventHandler;
+    onWheel?: RVWheelEventHandler;
+    stackBy?:
+      | 'x'
+      | 'y'
+      | 'radius'
+      | 'angle'
+      | 'color'
+      | 'fill'
+      | 'stroke'
+      | 'opacity'
+      | 'size';
+    style?: CSSProperties;
+  }
+  export class FlexibleHeightXYPlot<T = any> extends Component<
+    FlexibleHeightXYPlotProps & T
+  > {}
+}
+
+declare module 'react-vis/es/plot/series/abstract-series' {
+  import {AbstractSeries} from 'react-vis';
+  export default AbstractSeries;
+}
+
+declare module 'react-vis/es/plot/series/line-series' {
+  import {LineSeries} from 'react-vis';
+  export default LineSeries;
+}
+
+declare module 'react-vis/es/plot/series/line-series-canvas' {
+  import {LineSeriesCanvas} from 'react-vis';
+  export default LineSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/series/horizontal-bar-series' {
+  import {HorizontalBarSeries} from 'react-vis';
+  export default HorizontalBarSeries;
+}
+
+declare module 'react-vis/es/plot/series/horizontal-bar-series-canvas' {
+  import {HorizontalBarSeriesCanvas} from 'react-vis';
+  export default HorizontalBarSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/series/vertical-bar-series' {
+  import {VerticalBarSeries} from 'react-vis';
+  export default VerticalBarSeries;
+}
+
+declare module 'react-vis/es/plot/series/vertical-bar-series-canvas' {
+  import {VerticalBarSeriesCanvas} from 'react-vis';
+  export default VerticalBarSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/series/vertical-rect-series' {
+  import {VerticalRectSeries} from 'react-vis';
+  export default VerticalRectSeries;
+}
+
+declare module 'react-vis/es/plot/series/vertical-rect-series-canvas' {
+  import {VerticalRectSeriesCanvas} from 'react-vis';
+  export default VerticalRectSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/series/horizontal-rect-series' {
+  import {HorizontalRectSeries} from 'react-vis';
+  export default HorizontalRectSeries;
+}
+
+declare module 'react-vis/es/plot/series/horizontal-rect-series-canvas' {
+  import {HorizontalRectSeriesCanvas} from 'react-vis';
+  export default HorizontalRectSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/series/label-series' {
+  import {LabelSeries} from 'react-vis';
+  export default LabelSeries;
+}
+
+declare module 'react-vis/es/plot/series/polygon-series' {
+  import {PolygonSeries} from 'react-vis';
+  export default PolygonSeries;
+}
+
+declare module 'react-vis/es/plot/series/rect-series' {
+  import {RectSeries} from 'react-vis';
+  export default RectSeries;
+}
+
+declare module 'react-vis/es/plot/series/rect-series-canvas' {
+  import {RectSeriesCanvas} from 'react-vis';
+  export default RectSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/series/mark-series' {
+  import {MarkSeries} from 'react-vis';
+  export default MarkSeries;
+}
+
+declare module 'react-vis/es/plot/series/mark-series-canvas' {
+  import {MarkSeriesCanvas} from 'react-vis';
+  export default MarkSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/series/whisker-series' {
+  import {WhiskerSeries} from 'react-vis';
+  export default WhiskerSeries;
+}
+
+declare module 'react-vis/es/plot/series/heatmap-series' {
+  import {HeatmapSeries} from 'react-vis';
+  export default HeatmapSeries;
+}
+
+declare module 'react-vis/es/plot/series/hexbin-series' {
+  import {HexbinSeries} from 'react-vis';
+  export default HexbinSeries;
+}
+
+declare module 'react-vis/es/plot/series/contour-series' {
+  import {ContourSeries} from 'react-vis';
+  export default ContourSeries;
+}
+
+declare module 'react-vis/es/plot/series/custom-svg-series' {
+  import {CustomSVGSeries} from 'react-vis';
+  export default CustomSVGSeries;
+}
+
+declare module 'react-vis/es/plot/series/area-series' {
+  import {AreaSeries} from 'react-vis';
+  export default AreaSeries;
+}
+
+declare module 'react-vis/es/plot/series/arc-series' {
+  import {ArcSeries} from 'react-vis';
+  export default ArcSeries;
+}
+
+declare module 'react-vis/es/plot/series/line-mark-series' {
+  import {LineMarkSeries} from 'react-vis';
+  export default LineMarkSeries;
+}
+
+declare module 'react-vis/es/plot/series/line-mark-series-canvas' {
+  import {LineMarkSeriesCanvas} from 'react-vis';
+  export default LineMarkSeriesCanvas;
+}
+
+declare module 'react-vis/es/plot/hint' {
+  import {Hint} from 'react-vis';
+  export default Hint;
+}
+
+declare module 'react-vis/es/plot/borders' {
+  import {Borders} from 'react-vis';
+  export default Borders;
+}
+
+declare module 'react-vis/es/plot/crosshair' {
+  import {Crosshair} from 'react-vis';
+  export default Crosshair;
+}
+
+declare module 'react-vis/es/plot/xy-plot' {
+  import {XYPlot} from 'react-vis';
+  export default XYPlot;
+}
+
+declare module 'react-vis/es/plot/axis/decorative-axis' {
+  import {DecorativeAxis} from 'react-vis';
+  export default DecorativeAxis;
+}
+
+declare module 'react-vis/es/plot/axis/x-axis' {
+  import {XAxis} from 'react-vis';
+  export default XAxis;
+}
+
+declare module 'react-vis/es/plot/axis/y-axis' {
+  import {YAxis} from 'react-vis';
+  export default YAxis;
+}
+
+declare module 'react-vis/es/plot/circular-grid-lines' {
+  import {CircularGridLines} from 'react-vis';
+  export default CircularGridLines;
+}
+
+declare module 'react-vis/es/plot/grid-lines' {
+  import {GridLines} from 'react-vis';
+  export default GridLines;
+}
+
+declare module 'react-vis/es/plot/gradient-defs' {
+  import {GradientDefs} from 'react-vis';
+  export default GradientDefs;
+}
+
+declare module 'react-vis/es/plot/vertical-grid-lines' {
+  import {VerticalGridLines} from 'react-vis';
+  export default VerticalGridLines;
+}
+
+declare module 'react-vis/es/plot/horizontal-grid-lines' {
+  import {HorizontalGridLines} from 'react-vis';
+  export default HorizontalGridLines;
+}
+
+declare module 'react-vis/es/plot/voronoi' {
+  import {Voronoi} from 'react-vis';
+  export default Voronoi;
+}
+
+declare module 'react-vis/es/plot/highlight' {
+  import {Highlight} from 'react-vis';
+  export default Highlight;
+}
+
+declare module 'react-vis/es/legends/discrete-color-legend' {
+  import {DiscreteColorLegend} from 'react-vis';
+  export default DiscreteColorLegend;
+}
+
+declare module 'react-vis/es/legends/searchable-discrete-color-legend' {
+  import {SearchableDiscreteColorLegend} from 'react-vis';
+  export default SearchableDiscreteColorLegend;
+}
+
+declare module 'react-vis/es/legends/continuous-color-legend' {
+  import {ContinuousColorLegend} from 'react-vis';
+  export default ContinuousColorLegend;
+}
+
+declare module 'react-vis/es/legends/continuous-size-legend' {
+  import {ContinuousSizeLegend} from 'react-vis';
+  export default ContinuousSizeLegend;
+}
+
+declare module 'react-vis/es/treemap' {
+  import {Treemap} from 'react-vis';
+  export default Treemap;
+}
+
+declare module 'react-vis/es/radial-chart' {
+  import {RadialChart} from 'react-vis';
+  export default RadialChart;
+}
+
+declare module 'react-vis/es/radar-chart' {
+  import {RadarChart} from 'react-vis';
+  export default RadarChart;
+}
+
+declare module 'react-vis/es/parallel-coordinates' {
+  import {ParallelCoordinates} from 'react-vis';
+  export default ParallelCoordinates;
+}
+
+declare module 'react-vis/es/sankey' {
+  import {Sankey} from 'react-vis';
+  export default Sankey;
+}
+
+declare module 'react-vis/es/sunburst' {
+  import {Sunburst} from 'react-vis';
+  export default Sunburst;
+}
+
+declare module 'react-vis/es/utils/axis-utils' {
+  import {AxisUtils} from 'react-vis';
+  export default AxisUtils;
+}
+
+declare module 'react-vis/es/utils/scales-utils' {
+  import {ScaleUtils} from 'react-vis';
+  export default ScaleUtils;
+}
+
+declare module 'react-vis/es/make-vis-flexible' {
+  export {
+    FlexibleHeightXYPlot,
+    FlexibleWidthXYPlot,
+    FlexibleXYPlot,
+    makeHeightFlexible,
+    makeVisFlexible,
+    makeWidthFlexible,
+  } from 'react-vis';
+}

--- a/packages/react-vis/src/legends/continuous-color-legend.js
+++ b/packages/react-vis/src/legends/continuous-color-legend.js
@@ -39,22 +39,16 @@ const propTypes = {
   width: PropTypes.number
 };
 
-const defaultProps = {
-  className: '',
-  startColor: CONTINUOUS_COLOR_RANGE[0],
-  endColor: CONTINUOUS_COLOR_RANGE[1]
-};
-
 function ContinuousColorLegend({
-  startColor,
+  startColor = CONTINUOUS_COLOR_RANGE[0],
   midColor,
-  endColor,
+  endColor = CONTINUOUS_COLOR_RANGE[1],
   startTitle,
   midTitle,
   endTitle,
   height,
   width,
-  className
+  className = ''
 }) {
   const colors = [startColor];
   if (midColor) {
@@ -83,6 +77,5 @@ function ContinuousColorLegend({
 
 ContinuousColorLegend.displayName = 'ContinuousColorLegend';
 ContinuousColorLegend.propTypes = propTypes;
-ContinuousColorLegend.defaultProps = defaultProps;
 
 export default ContinuousColorLegend;

--- a/packages/react-vis/src/legends/continuous-size-legend.js
+++ b/packages/react-vis/src/legends/continuous-size-legend.js
@@ -36,22 +36,15 @@ const propTypes = {
   width: PropTypes.number
 };
 
-const defaultProps = {
-  circlesTotal: 10,
-  className: '',
-  endSize: 20,
-  startSize: 2
-};
-
 function ContinuousSizeLegend({
   startTitle,
   endTitle,
-  startSize,
-  endSize,
-  circlesTotal,
+  startSize = 2,
+  endSize = 20,
+  circlesTotal = 10,
   height,
   width,
-  className
+  className = ''
 }) {
   const circles = [];
   const step = (endSize - startSize) / (circlesTotal - 1);
@@ -92,6 +85,5 @@ function ContinuousSizeLegend({
 
 ContinuousSizeLegend.displayName = 'ContinuousSizeLegend';
 ContinuousSizeLegend.propTypes = propTypes;
-ContinuousSizeLegend.defaultProps = defaultProps;
 
 export default ContinuousSizeLegend;

--- a/packages/react-vis/src/legends/discrete-color-legend-item.js
+++ b/packages/react-vis/src/legends/discrete-color-legend-item.js
@@ -30,9 +30,9 @@ const STROKE_STYLES = {
 function DiscreteColorLegendItem({
   color,
   strokeDasharray,
-  strokeStyle,
+  strokeStyle = 'solid',
   strokeWidth,
-  disabled,
+  disabled = false,
   onClick,
   orientation,
   onMouseEnter,
@@ -82,10 +82,6 @@ DiscreteColorLegendItem.propTypes = {
   strokeDasharray: PropTypes.string,
   strokeWidth: PropTypes.number,
   strokeStyle: PropTypes.oneOf(Object.keys(STROKE_STYLES))
-};
-DiscreteColorLegendItem.defaultProps = {
-  disabled: false,
-  strokeStyle: 'solid'
 };
 DiscreteColorLegendItem.displayName = 'DiscreteColorLegendItem';
 

--- a/packages/react-vis/src/legends/discrete-color-legend.js
+++ b/packages/react-vis/src/legends/discrete-color-legend.js
@@ -26,14 +26,14 @@ import {DISCRETE_COLOR_RANGE} from 'theme';
 import {getCombinedClassName} from 'utils/styling-utils';
 
 function DiscreteColorLegend({
-  className,
-  colors,
+  className = '',
+  colors = DISCRETE_COLOR_RANGE,
   height,
   items,
   onItemClick,
   onItemMouseEnter,
   onItemMouseLeave,
-  orientation,
+  orientation = 'vertical',
   style,
   width
 }) {
@@ -90,12 +90,6 @@ DiscreteColorLegend.propTypes = {
   height: PropTypes.number,
   width: PropTypes.number,
   orientation: PropTypes.oneOf(['vertical', 'horizontal'])
-};
-
-DiscreteColorLegend.defaultProps = {
-  className: '',
-  colors: DISCRETE_COLOR_RANGE,
-  orientation: 'vertical'
 };
 
 export default DiscreteColorLegend;

--- a/packages/react-vis/src/legends/searchable-discrete-color-legend.js
+++ b/packages/react-vis/src/legends/searchable-discrete-color-legend.js
@@ -32,21 +32,17 @@ const propTypes = {
   searchFn: PropTypes.func
 };
 
-const defaultProps = {
-  className: '',
-  searchText: '',
-  searchFn: (items, s) =>
-    items.filter(
-      item =>
-        String(item.title || item)
-          .toLowerCase()
-          .indexOf(s) !== -1
-    )
-};
+const defaultSearchFn = (items, s) =>
+  items.filter(
+    item =>
+      String(item.title || item)
+        .toLowerCase()
+        .indexOf(s) !== -1
+  );
 
 function SearchableDiscreteColorLegend(props) {
   const {
-    className,
+    className = '',
     colors,
     height,
     items,
@@ -55,9 +51,9 @@ function SearchableDiscreteColorLegend(props) {
     onItemMouseLeave,
     onSearchChange,
     orientation,
-    searchFn,
+    searchFn = defaultSearchFn,
     searchPlaceholder,
-    searchText,
+    searchText = '',
     width
   } = props;
   const onChange = onSearchChange
@@ -93,7 +89,6 @@ function SearchableDiscreteColorLegend(props) {
 }
 
 SearchableDiscreteColorLegend.propTypes = propTypes;
-SearchableDiscreteColorLegend.defaultProps = defaultProps;
 SearchableDiscreteColorLegend.displayName = 'SearchableDiscreteColorLegend';
 
 export default SearchableDiscreteColorLegend;

--- a/packages/react-vis/src/plot/axis/axis-line.js
+++ b/packages/react-vis/src/plot/axis/axis-line.js
@@ -33,11 +33,7 @@ const propTypes = {
   width: PropTypes.number.isRequired
 };
 
-const defaultProps = {
-  style: {}
-};
-
-function AxisLine({orientation, width, height, style}) {
+function AxisLine({orientation, width, height, style = {}}) {
   let lineProps;
   if (orientation === LEFT) {
     lineProps = {
@@ -73,7 +69,6 @@ function AxisLine({orientation, width, height, style}) {
   );
 }
 
-AxisLine.defaultProps = defaultProps;
 AxisLine.displayName = 'AxisLine';
 AxisLine.propTypes = propTypes;
 

--- a/packages/react-vis/src/plot/axis/axis-title.js
+++ b/packages/react-vis/src/plot/axis/axis-title.js
@@ -28,9 +28,6 @@ import {ORIENTATION} from 'utils/axis-utils';
 const ADJUSTMENT_FOR_TEXT_SIZE = 16;
 const MARGIN = 6;
 const {LEFT, RIGHT, TOP, BOTTOM} = ORIENTATION;
-const defaultProps = {
-  position: 'end'
-};
 
 /**
  * Compute transformations, keyed by orientation
@@ -129,7 +126,14 @@ const propTypes = {
   title: PropTypes.string.isRequired
 };
 
-function AxisTitle({orientation, position, width, height, style, title}) {
+function AxisTitle({
+  orientation,
+  position = 'end',
+  width,
+  height,
+  style,
+  title
+}) {
   const outerGroupTranslateX = orientation === LEFT ? width : 0;
   const outerGroupTranslateY = orientation === TOP ? height : 0;
   const outerGroupTransform = `translate(${outerGroupTranslateX}, ${outerGroupTranslateY})`;
@@ -149,5 +153,4 @@ function AxisTitle({orientation, position, width, height, style, title}) {
 
 AxisTitle.displayName = 'AxisTitle';
 AxisTitle.propTypes = propTypes;
-AxisTitle.defaultProps = defaultProps;
 export default AxisTitle;

--- a/packages/react-vis/src/plot/axis/x-axis.js
+++ b/packages/react-vis/src/plot/axis/x-axis.js
@@ -33,19 +33,14 @@ const propTypes = {
   orientation: PropTypes.oneOf([TOP, BOTTOM])
 };
 
-const defaultProps = {
-  orientation: BOTTOM,
-  attr: 'x',
-  attrAxis: 'y'
-};
-
-function XAxis(props) {
-  return <Axis {...props} />;
+function XAxis({orientation = BOTTOM, attr = 'x', attrAxis = 'y', ...rest}) {
+  return (
+    <Axis {...rest} orientation={orientation} attr={attr} attrAxis={attrAxis} />
+  );
 }
 
 XAxis.displayName = 'XAxis';
 XAxis.propTypes = propTypes;
-XAxis.defaultProps = defaultProps;
 XAxis.requiresSVG = true;
 
 export default XAxis;

--- a/packages/react-vis/src/plot/axis/y-axis.js
+++ b/packages/react-vis/src/plot/axis/y-axis.js
@@ -33,19 +33,14 @@ const propTypes = {
   orientation: PropTypes.oneOf([LEFT, RIGHT])
 };
 
-const defaultProps = {
-  orientation: LEFT,
-  attr: 'y',
-  attrAxis: 'x'
-};
-
-function YAxis(props) {
-  return <Axis {...props} />;
+function YAxis({orientation = LEFT, attr = 'y', attrAxis = 'x', ...rest}) {
+  return (
+    <Axis {...rest} orientation={orientation} attr={attr} attrAxis={attrAxis} />
+  );
 }
 
 YAxis.displayName = 'YAxis';
 YAxis.propTypes = propTypes;
-YAxis.defaultProps = defaultProps;
 YAxis.requiresSVG = true;
 
 export default YAxis;

--- a/packages/react-vis/src/plot/borders.js
+++ b/packages/react-vis/src/plot/borders.js
@@ -46,6 +46,14 @@ const CLASSES = {
   top: 'rv-xy-plot__borders-top'
 };
 
+const DEFAULT_STYLE = {
+  all: {},
+  bottom: {},
+  left: {},
+  right: {},
+  top: {}
+};
+
 function Borders(props) {
   const {
     marginTop,
@@ -54,8 +62,8 @@ function Borders(props) {
     marginRight,
     innerWidth,
     innerHeight,
-    style,
-    className
+    style = DEFAULT_STYLE,
+    className = ''
   } = props;
   const height = innerHeight + marginTop + marginBottom;
   const width = innerWidth + marginLeft + marginRight;
@@ -98,16 +106,6 @@ function Borders(props) {
 }
 
 Borders.displayName = 'Borders';
-Borders.defaultProps = {
-  className: '',
-  style: {
-    all: {},
-    bottom: {},
-    left: {},
-    right: {},
-    top: {}
-  }
-};
 Borders.propTypes = propTypes;
 Borders.requiresSVG = true;
 

--- a/packages/react-vis/src/plot/gradient-defs.js
+++ b/packages/react-vis/src/plot/gradient-defs.js
@@ -26,7 +26,7 @@ import {getCombinedClassName} from 'utils/styling-utils';
 const predefinedClassName = 'rv-gradient-defs';
 
 function GradientDefs(props) {
-  const {className} = props;
+  const {className = ''} = props;
   return (
     <defs className={getCombinedClassName(predefinedClassName, className)}>
       {props.children}
@@ -38,9 +38,6 @@ GradientDefs.displayName = 'GradientDefs';
 GradientDefs.requiresSVG = true;
 GradientDefs.propTypes = {
   className: PropTypes.string
-};
-GradientDefs.defaultProps = {
-  className: ''
 };
 
 export default GradientDefs;

--- a/packages/react-vis/src/plot/horizontal-grid-lines.js
+++ b/packages/react-vis/src/plot/horizontal-grid-lines.js
@@ -32,18 +32,12 @@ const propTypes = {
   direction: PropTypes.oneOf([HORIZONTAL])
 };
 
-const defaultProps = {
-  direction: HORIZONTAL,
-  attr: 'y'
-};
-
-function HorizontalGridLines(props) {
-  return <GridLines {...props} />;
+function HorizontalGridLines({direction = HORIZONTAL, attr = 'y', ...rest}) {
+  return <GridLines {...rest} direction={direction} attr={attr} />;
 }
 
 HorizontalGridLines.displayName = 'HorizontalGridLines';
 HorizontalGridLines.propTypes = propTypes;
-HorizontalGridLines.defaultProps = defaultProps;
 HorizontalGridLines.requiresSVG = true;
 
 export default HorizontalGridLines;

--- a/packages/react-vis/src/plot/vertical-grid-lines.js
+++ b/packages/react-vis/src/plot/vertical-grid-lines.js
@@ -32,18 +32,12 @@ const propTypes = {
   direction: PropTypes.oneOf([VERTICAL])
 };
 
-const defaultProps = {
-  direction: VERTICAL,
-  attr: 'x'
-};
-
-function VerticalGridLines(props) {
-  return <GridLines {...props} />;
+function VerticalGridLines({direction = VERTICAL, attr = 'x', ...rest}) {
+  return <GridLines {...rest} direction={direction} attr={attr} />;
 }
 
 VerticalGridLines.displayName = 'VerticalGridLines';
 VerticalGridLines.propTypes = propTypes;
-VerticalGridLines.defaultProps = defaultProps;
 VerticalGridLines.requiresSVG = true;
 
 export default VerticalGridLines;

--- a/packages/react-vis/src/plot/voronoi.js
+++ b/packages/react-vis/src/plot/voronoi.js
@@ -29,14 +29,14 @@ function getExtent({innerWidth, innerHeight, marginLeft, marginTop}) {
 
 function Voronoi(props) {
   const {
-    className,
+    className = '',
     extent,
     nodes,
-    onBlur,
-    onClick,
-    onMouseUp,
-    onMouseDown,
-    onHover,
+    onBlur = NOOP,
+    onClick = NOOP,
+    onMouseUp = NOOP,
+    onMouseDown = NOOP,
+    onHover = NOOP,
     polygonStyle,
     style,
     x,
@@ -96,14 +96,6 @@ function Voronoi(props) {
 
 Voronoi.requiresSVG = true;
 Voronoi.displayName = 'Voronoi';
-Voronoi.defaultProps = {
-  className: '',
-  onBlur: NOOP,
-  onClick: NOOP,
-  onHover: NOOP,
-  onMouseDown: NOOP,
-  onMouseUp: NOOP
-};
 
 Voronoi.propTypes = {
   className: PropTypes.string,

--- a/packages/react-vis/src/radar-chart/index.js
+++ b/packages/react-vis/src/radar-chart/index.js
@@ -35,6 +35,22 @@ import DecorativeAxis from 'plot/axis/decorative-axis';
 
 const predefinedClassName = 'rv-radar-chart';
 const DEFAULT_FORMAT = format('.2r');
+const DEFAULT_STYLE = {
+  axes: {
+    line: {},
+    ticks: {},
+    text: {}
+  },
+  labels: {
+    fontSize: 10,
+    textAnchor: 'middle'
+  },
+  polygons: {
+    strokeWidth: 0.5,
+    strokeOpacity: 1,
+    fillOpacity: 0.1
+  }
+};
 /**
  * Generate axes for each of the domains
  * @param {Object} props
@@ -257,30 +273,28 @@ function getPolygonPoints(props) {
   });
 }
 
-function RadarChart(props) {
-  const {
-    animation,
-    className,
-    children,
-    colorRange,
-    data,
-    domains,
-    height,
-    hideInnerMostValues,
-    margin,
-    onMouseLeave,
-    onMouseEnter,
-    startingAngle,
-    style,
-    tickFormat,
-    width,
-    renderAxesOverPolygons,
-    onValueMouseOver,
-    onValueMouseOut,
-    onSeriesMouseOver,
-    onSeriesMouseOut
-  } = props;
-
+function RadarChart({
+  animation,
+  className = '',
+  children,
+  colorRange = DISCRETE_COLOR_RANGE,
+  data,
+  domains,
+  height,
+  hideInnerMostValues = true,
+  margin,
+  onMouseLeave,
+  onMouseEnter,
+  startingAngle = Math.PI / 2,
+  style = DEFAULT_STYLE,
+  tickFormat = DEFAULT_FORMAT,
+  width,
+  renderAxesOverPolygons = false,
+  onValueMouseOver,
+  onValueMouseOut,
+  onSeriesMouseOver,
+  onSeriesMouseOut
+}) {
   const axes = getAxes({
     domains,
     animation,
@@ -378,30 +392,4 @@ RadarChart.propTypes = {
   onSeriesMouseOver: PropTypes.func,
   onSeriesMouseOut: PropTypes.func
 };
-RadarChart.defaultProps = {
-  className: '',
-  colorType: 'category',
-  colorRange: DISCRETE_COLOR_RANGE,
-  hideInnerMostValues: true,
-  startingAngle: Math.PI / 2,
-  style: {
-    axes: {
-      line: {},
-      ticks: {},
-      text: {}
-    },
-    labels: {
-      fontSize: 10,
-      textAnchor: 'middle'
-    },
-    polygons: {
-      strokeWidth: 0.5,
-      strokeOpacity: 1,
-      fillOpacity: 0.1
-    }
-  },
-  tickFormat: DEFAULT_FORMAT,
-  renderAxesOverPolygons: false
-};
-
 export default RadarChart;

--- a/packages/react-vis/src/radial-chart/index.js
+++ b/packages/react-vis/src/radial-chart/index.js
@@ -100,15 +100,47 @@ function getMaxRadius(width, height) {
   return Math.min(width, height) / 2 - DEFAULT_RADIUS_MARGIN;
 }
 
-function RadialChart(props) {
-  const {
+function RadialChart({
+  animation,
+  className = '',
+  children,
+  colorType = 'category',
+  colorRange = DISCRETE_COLOR_RANGE,
+  data,
+  getAngle = d => d.angle,
+  getAngle0 = d => d.angle0,
+  getLabel = d => d.label,
+  getRadius = d => d.radius,
+  getRadius0 = d => d.radius0,
+  getSubLabel = d => d.subLabel,
+  height,
+  hideRootNode,
+  innerRadius,
+  labelsAboveChildren,
+  labelsRadiusMultiplier,
+  labelsStyle,
+  margin,
+  onMouseLeave,
+  onMouseEnter,
+  padAngle = 0,
+  radius,
+  showLabels,
+  style,
+  width,
+  ...restProps
+}) {
+  const props = {
     animation,
     className,
     children,
     colorType,
+    colorRange,
     data,
     getAngle,
+    getAngle0,
     getLabel,
+    getRadius,
+    getRadius0,
     getSubLabel,
     height,
     hideRootNode,
@@ -119,11 +151,13 @@ function RadialChart(props) {
     margin,
     onMouseLeave,
     onMouseEnter,
+    padAngle,
     radius,
     showLabels,
     style,
-    width
-  } = props;
+    width,
+    ...restProps
+  };
   const mappedData = getWedgesToRender({
     data,
     height,
@@ -216,17 +250,4 @@ RadialChart.propTypes = {
   subLabel: PropTypes.func,
   width: PropTypes.number.isRequired
 };
-RadialChart.defaultProps = {
-  className: '',
-  colorType: 'category',
-  colorRange: DISCRETE_COLOR_RANGE,
-  padAngle: 0,
-  getAngle: d => d.angle,
-  getAngle0: d => d.angle0,
-  getRadius: d => d.radius,
-  getRadius0: d => d.radius0,
-  getLabel: d => d.label,
-  getSubLabel: d => d.subLabel
-};
-
 export default RadialChart;

--- a/packages/react-vis/src/sankey/index.js
+++ b/packages/react-vis/src/sankey/index.js
@@ -34,8 +34,39 @@ const DEFAULT_MARGINS = {
   bottom: 20
 };
 
-function Sankey(props) {
-  const {
+const DEFAULT_STYLE = {
+  links: {},
+  rects: {},
+  labels: {}
+};
+
+function Sankey({
+  align = 'justify',
+  animation,
+  children,
+  className = '',
+  hasVoronoi = false,
+  height,
+  hideLabels = false,
+  labelRotation = 0,
+  layout = 50,
+  links,
+  linkOpacity,
+  margin = DEFAULT_MARGINS,
+  nodePadding = 10,
+  nodes,
+  nodeWidth = 10,
+  onValueClick = NOOP,
+  onValueMouseOver = NOOP,
+  onValueMouseOut = NOOP,
+  onLinkClick = NOOP,
+  onLinkMouseOver = NOOP,
+  onLinkMouseOut = NOOP,
+  style = DEFAULT_STYLE,
+  width,
+  ...restProps
+}) {
+  const props = {
     align,
     animation,
     children,
@@ -58,8 +89,9 @@ function Sankey(props) {
     onLinkMouseOver,
     onLinkMouseOut,
     style,
-    width
-  } = props;
+    width,
+    ...restProps
+  };
   const nodesCopy = [...new Array(nodes.length)].map((e, i) => ({
     ...nodes[i]
   }));
@@ -173,29 +205,6 @@ function Sankey(props) {
     </XYPlot>
   );
 }
-
-Sankey.defaultProps = {
-  align: 'justify',
-  className: '',
-  hasVoronoi: false,
-  hideLabels: false,
-  labelRotation: 0,
-  layout: 50,
-  margin: DEFAULT_MARGINS,
-  nodePadding: 10,
-  nodeWidth: 10,
-  onValueMouseOver: NOOP,
-  onValueClick: NOOP,
-  onValueMouseOut: NOOP,
-  onLinkClick: NOOP,
-  onLinkMouseOver: NOOP,
-  onLinkMouseOut: NOOP,
-  style: {
-    links: {},
-    rects: {},
-    labels: {}
-  }
-};
 
 Sankey.propTypes = {
   align: PropTypes.oneOf(['justify', 'left', 'right', 'center']),

--- a/packages/react-vis/src/sunburst/index.js
+++ b/packages/react-vis/src/sunburst/index.js
@@ -123,21 +123,40 @@ function buildLabels(mappedData, accessors) {
 
 const NOOP = () => {};
 
-function Sunburst(props) {
-  const {
+function Sunburst({
+  getAngle = d => d.angle,
+  getAngle0 = d => d.angle0,
+  animation,
+  className = '',
+  children,
+  colorType = 'literal',
+  data,
+  getColor = d => d.color,
+  height,
+  hideRootNode = false,
+  getLabel = d => d.label,
+  width,
+  getSize = d => d.size,
+  padAngle = 0,
+  ...restProps
+}) {
+  const props = {
     getAngle,
     getAngle0,
     animation,
     className,
     children,
+    colorType,
     data,
+    getColor,
     height,
     hideRootNode,
     getLabel,
     width,
     getSize,
-    colorType
-  } = props;
+    padAngle,
+    ...restProps
+  };
   const mappedData = getNodesToRender({
     data,
     height,
@@ -216,16 +235,4 @@ Sunburst.propTypes = {
   width: PropTypes.number.isRequired,
   padAngle: PropTypes.oneOfType([PropTypes.func, PropTypes.number])
 };
-Sunburst.defaultProps = {
-  getAngle: d => d.angle,
-  getAngle0: d => d.angle0,
-  className: '',
-  colorType: 'literal',
-  getColor: d => d.color,
-  hideRootNode: false,
-  getLabel: d => d.label,
-  getSize: d => d.size,
-  padAngle: 0
-};
-
 export default Sunburst;

--- a/packages/react-vis/src/treemap/index.js
+++ b/packages/react-vis/src/treemap/index.js
@@ -91,9 +91,55 @@ function _getScaleFns(props) {
   };
 }
 
-function Treemap(props) {
+const defaultSortFunction = (a, b, accessor) => {
+  if (!accessor) {
+    return 0;
+  }
+  return accessor(a) - accessor(b);
+};
+
+function Treemap({
+  className = '',
+  colorRange = CONTINUOUS_COLOR_RANGE,
+  _colorValue = DEFAULT_COLOR,
+  data = {children: []},
+  hideRootNode = false,
+  margin = DEFAULT_MARGINS,
+  mode = 'squarify',
+  onLeafClick = NOOP,
+  onLeafMouseOver = NOOP,
+  onLeafMouseOut = NOOP,
+  opacityType = OPACITY_TYPE,
+  _opacityValue = DEFAULT_OPACITY,
+  padding = 1,
+  sortFunction = defaultSortFunction,
+  getSize = d => d.size,
+  getColor = d => d.color,
+  getLabel = d => d.title,
+  ...restProps
+}) {
+  const props = {
+    className,
+    colorRange,
+    _colorValue,
+    data,
+    hideRootNode,
+    margin,
+    mode,
+    onLeafClick,
+    onLeafMouseOver,
+    onLeafMouseOut,
+    opacityType,
+    _opacityValue,
+    padding,
+    sortFunction,
+    getSize,
+    getColor,
+    getLabel,
+    ...restProps
+  };
   const scales = _getScaleFns(props);
-  const innerDimensions = getInnerDimensions(props, props.margin);
+  const innerDimensions = getInnerDimensions(props, margin);
 
   /**
    * Create the list of nodes to render.
@@ -180,30 +226,4 @@ Treemap.propTypes = {
   getColor: PropTypes.func
 };
 
-Treemap.defaultProps = {
-  className: '',
-  colorRange: CONTINUOUS_COLOR_RANGE,
-  _colorValue: DEFAULT_COLOR,
-  data: {
-    children: []
-  },
-  hideRootNode: false,
-  margin: DEFAULT_MARGINS,
-  mode: 'squarify',
-  onLeafClick: NOOP,
-  onLeafMouseOver: NOOP,
-  onLeafMouseOut: NOOP,
-  opacityType: OPACITY_TYPE,
-  _opacityValue: DEFAULT_OPACITY,
-  padding: 1,
-  sortFunction: (a, b, accessor) => {
-    if (!accessor) {
-      return 0;
-    }
-    return accessor(a) - accessor(b);
-  },
-  getSize: d => d.size,
-  getColor: d => d.color,
-  getLabel: d => d.title
-};
 export default Treemap;

--- a/packages/react-vis/tests/react19-smoke.test.js
+++ b/packages/react-vis/tests/react19-smoke.test.js
@@ -1,0 +1,219 @@
+// Temporary smoke test for the React 19 upgrade experiment.
+// Renders representative charts without enzyme to check whether the library
+// itself is compatible with React 19 (server render + client createRoot).
+import 'regenerator-runtime/runtime';
+import React from 'react';
+import {renderToStaticMarkup} from 'react-dom/server';
+
+import XYPlot from 'plot/xy-plot';
+import XAxis from 'plot/axis/x-axis';
+import YAxis from 'plot/axis/y-axis';
+import HorizontalGridLines from 'plot/horizontal-grid-lines';
+import VerticalGridLines from 'plot/vertical-grid-lines';
+import LineSeries from 'plot/series/line-series';
+import MarkSeries from 'plot/series/mark-series';
+import VerticalBarSeries from 'plot/series/vertical-bar-series';
+import AreaSeries from 'plot/series/area-series';
+import LabelSeries from 'plot/series/label-series';
+import Crosshair from 'plot/crosshair';
+import DiscreteColorLegend from 'legends/discrete-color-legend';
+import ContinuousColorLegend from 'legends/continuous-color-legend';
+import RadialChart from 'radial-chart';
+import RadarChart from 'radar-chart';
+import Sunburst from 'sunburst';
+import Treemap from 'treemap';
+import Sankey from 'sankey';
+
+const DATA = [{x: 1, y: 3}, {x: 2, y: 5}, {x: 3, y: 15}, {x: 4, y: 12}];
+
+describe('React 19 smoke tests (server render)', () => {
+  test('React version under test is 19', () => {
+    expect(React.version).toMatch(/^19\./);
+  });
+
+  test('XYPlot with axes, grid lines and series', () => {
+    const html = renderToStaticMarkup(
+      <XYPlot width={300} height={300}>
+        <HorizontalGridLines />
+        <VerticalGridLines />
+        <XAxis title="X" />
+        <YAxis title="Y" />
+        <LineSeries data={DATA} />
+        <MarkSeries data={DATA} />
+        <AreaSeries data={DATA} />
+        <VerticalBarSeries data={DATA} />
+        <LabelSeries data={DATA.map(d => ({...d, label: String(d.y)}))} />
+        <Crosshair values={[DATA[1]]} />
+      </XYPlot>
+    );
+    expect(html).toContain('rv-xy-plot');
+    expect(html).toContain('rv-xy-plot__axis');
+    expect(html).toContain('rv-xy-plot__grid-lines');
+    expect(html).toContain('rv-xy-plot__series--line');
+  });
+
+  test('legends', () => {
+    const legend = renderToStaticMarkup(
+      <DiscreteColorLegend items={['a', 'b', 'c']} />
+    );
+    expect(legend).toContain('rv-discrete-color-legend-item');
+    const continuous = renderToStaticMarkup(
+      <ContinuousColorLegend startTitle={0} endTitle={100} />
+    );
+    expect(continuous).toContain('rv-gradient');
+  });
+
+  test('radial and radar charts', () => {
+    const radial = renderToStaticMarkup(
+      <RadialChart
+        width={300}
+        height={300}
+        data={[{angle: 1}, {angle: 2}, {angle: 5}]}
+      />
+    );
+    expect(radial).toContain('rv-radial-chart');
+    const radar = renderToStaticMarkup(
+      <RadarChart
+        width={300}
+        height={300}
+        data={[{a: 1, b: 2, c: 3}]}
+        domains={[
+          {name: 'a', domain: [0, 4]},
+          {name: 'b', domain: [0, 4]},
+          {name: 'c', domain: [0, 4]}
+        ]}
+      />
+    );
+    expect(radar).toContain('rv-radar-chart');
+  });
+
+  test('sunburst, treemap and sankey', () => {
+    const sunburst = renderToStaticMarkup(
+      <Sunburst
+        width={300}
+        height={300}
+        data={{title: 'root', children: [{title: 'a', size: 1}]}}
+      />
+    );
+    expect(sunburst).toContain('rv-sunburst');
+    const treemap = renderToStaticMarkup(
+      <Treemap
+        width={300}
+        height={300}
+        data={{title: 'root', children: [{title: 'a', size: 10}]}}
+      />
+    );
+    expect(treemap).toContain('rv-treemap');
+    const sankey = renderToStaticMarkup(
+      <Sankey
+        width={300}
+        height={300}
+        nodes={[{name: 'a'}, {name: 'b'}]}
+        links={[{source: 0, target: 1, value: 10}]}
+      />
+    );
+    expect(sankey).toContain('rv-sankey');
+  });
+});
+
+describe('React 19 smoke tests (client render)', () => {
+  test('createRoot mounts and updates an XYPlot', async () => {
+    const {createRoot} = require('react-dom/client');
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    const {act} = React;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <XYPlot width={300} height={300}>
+          <XAxis />
+          <YAxis />
+          <LineSeries data={DATA} />
+        </XYPlot>
+      );
+    });
+    expect(container.innerHTML).toContain('rv-xy-plot');
+    await act(async () => {
+      root.render(
+        <XYPlot width={300} height={300}>
+          <XAxis />
+          <YAxis />
+          <LineSeries data={DATA.map(d => ({...d, y: d.y * 2}))} />
+        </XYPlot>
+      );
+    });
+    expect(container.innerHTML).toContain('rv-xy-plot__series--line');
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test('animated series (react-motion) mounts and updates', async () => {
+    const {createRoot} = require('react-dom/client');
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    const {act} = React;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <XYPlot width={300} height={300}>
+          <LineSeries animation data={DATA} />
+        </XYPlot>
+      );
+    });
+    expect(container.innerHTML).toContain('rv-xy-plot__series--line');
+    await act(async () => {
+      root.render(
+        <XYPlot width={300} height={300}>
+          <LineSeries
+            animation
+            data={DATA.map(d => ({...d, y: d.y + 1}))}
+          />
+        </XYPlot>
+      );
+    });
+    expect(container.innerHTML).toContain('rv-xy-plot__series--line');
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test('StrictMode mount with animation and data update', async () => {
+    const {createRoot} = require('react-dom/client');
+    global.IS_REACT_ACT_ENVIRONMENT = true;
+    const {act, StrictMode} = React;
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <XYPlot width={300} height={300}>
+            <XAxis />
+            <LineSeries animation data={DATA} />
+          </XYPlot>
+        </StrictMode>
+      );
+    });
+    expect(container.innerHTML).toContain('rv-xy-plot__series--line');
+    await act(async () => {
+      root.render(
+        <StrictMode>
+          <XYPlot width={300} height={300}>
+            <XAxis />
+            <LineSeries
+              animation
+              data={DATA.map(d => ({...d, y: d.y * 3}))}
+            />
+          </XYPlot>
+        </StrictMode>
+      );
+    });
+    expect(container.innerHTML).toContain('rv-xy-plot__series--line');
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12775,7 +12775,7 @@ react-dom@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-dom@^16.0.0, react-dom@^16.8.3:
+react-dom@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha1-wb03MxoEhsB47lTEdAcgmTsuDn8=
@@ -12784,6 +12784,13 @@ react-dom@^16.0.0, react-dom@^16.8.3:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-dom@^19.0.0:
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.8.tgz#3b46b9eeda877cdff2cf13d2770fff4ae36c2ec2"
+  integrity sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==
+  dependencies:
+    scheduler "^0.27.0"
 
 react-draggable@^4.0.3:
   version "4.4.2"
@@ -12884,6 +12891,11 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-i
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha1-eJcppNw23imZ3BVt1sHZwYzqVqQ=
+
+react-is@^19.2.8:
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.8.tgz#09826f9fbc187bc668e3e5c62edc001f804d5018"
+  integrity sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -13031,7 +13043,7 @@ react-syntax-highlighter@^11.0.2:
     prismjs "^1.8.4"
     refractor "^2.4.1"
 
-react-test-renderer@^16.0.0-0, react-test-renderer@^16.13.1:
+react-test-renderer@^16.0.0-0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
   integrity sha1-3iXqNY2QEmBt5R4BLZdC5/Deq8E=
@@ -13040,6 +13052,14 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.13.1:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.19.1"
+
+react-test-renderer@^19.0.0:
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.2.8.tgz#f4fb8c2a97c864ba708aec61d782a9bb725b672b"
+  integrity sha512-GHKPaDRaNYU24PHTLG8Bx8VMY9t+qNfxQbt/Yjp7aMWBkKU6766SR0n6TnYu7P5I1MfEuAMUadqiyDHyI4Yy9Q==
+  dependencies:
+    react-is "^19.2.8"
+    scheduler "^0.27.0"
 
 react-textarea-autosize@^7.1.0:
   version "7.1.2"
@@ -13082,7 +13102,7 @@ react@^15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react@^16.0.0, react@^16.8.3:
+react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha1-LoGIIvGpdDEiwGPWQQ2FweOv5I4=
@@ -13090,6 +13110,11 @@ react@^16.0.0, react@^16.8.3:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@^19.0.0:
+  version "19.2.8"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.8.tgz#a80663dbb58d69c6fe3fd291d3cb324e8a7dff2d"
+  integrity sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -13864,6 +13889,11 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Prepare the react-vis package for React 19 consumers:

- Replace defaultProps with destructured parameter defaults in all 19 function components (React 19 removed defaultProps support for function components). Class components keep theirs, which React 19 still supports. Components that spread `...props` into children (RadialChart, Sankey, Sunburst, Treemap, XAxis/YAxis, grid lines) rebuild or re-pass the defaulted values so nothing is lost in the spread.
- Bump react/react-dom/react-test-renderer devDeps to ^19 and widen the peer range to ^16.8.3 || ^17 || ^18 || ^19.
- Point package.json "types" at react-vis.d.ts and ship it in "files", so consumers no longer need to vendor the declarations inline.
- Add an enzyme-free smoke suite (jest.react19.config.js + tests/react19-smoke.test.js) proving SSR and createRoot mount/update/unmount work on React 19 for all major chart types, including the react-motion animation path. Run with: npx jest --config jest.react19.config.js
- Shim queueMicrotask/MessageChannel/TextEncoder (jest.polyfills.js) for jest 25's sandbox, which predates them.

Known state: the existing enzyme suite cannot run against React 19 - enzyme-adapter-react-16 reads React internals removed in 19 and no adapter exists for 18/19. Migrating those 48 suites to React Testing Library is the remaining work to get CI green on React 19.